### PR TITLE
FIX: Specifying verbosity now has the expected outcome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+build/
+dist/
+ASAPTools.egg-info/

--- a/source/asaptools/vprinter.py
+++ b/source/asaptools/vprinter.py
@@ -104,5 +104,5 @@ class VPrinter(object):
         if 'verbosity' in kwargs and type(kwargs['verbosity']) is int:
             verbosity = kwargs['verbosity']
 
-        if verbosity < self.verbosity:
+        if verbosity <= self.verbosity:
             print self.to_str(*args, **kwargs)


### PR DESCRIPTION
The problem was this: calling a vprinter class object to print something with a specified verbosity would not print that - if the class was instantiated with that exact same verbosity. For example, calling vprinter object with verbosity 2 would not have printed the message if self.verbosity was itself 2, which i think is counterintuitive. If the class has been constructed with default verbosity 2, it should print everything with verbosity less than or equal to 2. 
