### PR TITLE
Adding bugfix: special catch for dtype='c' arrays (not bufferable)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,3 +73,12 @@ Version 0.5.3
 3 March 2016:
 
 - Updates just for PyPI release
+
+
+Version 0.5.4
+-------------
+
+4 March 2016:
+
+- Bugfix: Special catch for dtype='c' (C-type char arrays) in check for 
+  Numpy arrays being bufferable

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ tasks, from managing print messages with a set verbosity level, to
 keeping timing information, to managing simple MPI communication.
 
 :AUTHORS: Kevin Paul, John Dennis, Sheri Mickelson, Haiying Xu
-:COPYRIGHT: 2015, University Corporation for Atmospheric Research
+:COPYRIGHT: 2016, University Corporation for Atmospheric Research
 :LICENSE: See the LICENSE.rst file for details
 
 Send questions and comments to Kevin Paul (kpaul@ucar.edu).
@@ -33,7 +33,7 @@ Dependencies
 
 All of the ASAP Python Toolbox are written to work with Python 2.7+ (but not
 Python 3.0+). The vprinter, timekeeper, and partition modules are pure
-Python. The simplecomm module depends on mpi4py (>-1.3).
+Python. The simplecomm module depends on mpi4py (>=1.3).
 
 This implies the dependency:
 
@@ -57,7 +57,7 @@ Obtaining the Source Code
 Currently, the most up-to-date source code is available via git from the
 site::
 
-    https://github.com/NCAR-CISL-ASAP/ASAPPyTools
+    https://github.com/NCAR/ASAPPyTools
 
 Check out the most recent tag.  The source is available in read-only
 mode to everyone, but special permissions can be given to those to make
@@ -69,7 +69,7 @@ Building & Installation
 Installation of the ASAP Python Toolbox is very simple. After checking out the
 source from the above svn link, via::
 
-    $  git clone https://github.com/NCAR-CISL-ASAP/ASAPPyTools
+    $  git clone https://github.com/NCAR/ASAPPyTools
 
 change into the top-level source directory, check out the most recent tag,
 and run the Python distutils setup. On unix, this involves::

--- a/source/asaptools/simplecomm.py
+++ b/source/asaptools/simplecomm.py
@@ -559,7 +559,8 @@ class SimpleCommMPI(SimpleComm):
             if hasattr(self._mpi, '_typedict_c'):
                 return (obj.dtype.char in self._mpi._typedict_c)
             elif hasattr(self._mpi, '__CTypeDict__'):
-                return (obj.dtype.char in self._mpi.__CTypeDict__)
+                return (obj.dtype.char in self._mpi.__CTypeDict__ and
+                        obj.dtype.char != 'c')
             else:
                 return False
         else:

--- a/source/asaptools/version.py
+++ b/source/asaptools/version.py
@@ -1,2 +1,2 @@
 # Current package version
-__version__ = '0.5.3'
+__version__ = '0.5.4'


### PR DESCRIPTION
This catch is only applied if using mpi4py < 2.0.0 (i.e., 1.3.1)
